### PR TITLE
chore: gh-page exclude from protection and presubmit job

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,6 +71,10 @@ branch-protection:
       #     - tide
       exclude:
         - "^dependabot/" # don't protect branches created by dependabot
+      repos:
+        docs:
+          branches:
+            protect: false
 
 log_level: debug
 pod_namespace: test-pods

--- a/config/jobs/docs/presubmits.yaml
+++ b/config/jobs/docs/presubmits.yaml
@@ -1,0 +1,11 @@
+presubmits:
+  kubecoins/docs:
+  - name: pull-docs-build-test
+    always_run: true
+    optional: false
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210217-8c72491-1.19
+        command:
+        - "make docs-build"


### PR DESCRIPTION
Exclude branch protection from gh-pages for the docs repo. Also added a pre-submit job for the docs repo

Signed-off-by: Richard Case <198425+richardcase@users.noreply.github.com>

```release-notes
NONE
```